### PR TITLE
Support passing `verbose` keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ At the moment there are two ways to run `@testitem`s: with the integrated test U
 
 #### Integrating with the base test system
 
-If you want your tests to run when a user calls the regular base test functionality, or have you your tests run during CI runs, you can simplye add this package TestItemRunner.jl as a test dependency to your package, and then add this content as your `test/runtests.jl` file:
+If you want your tests to run when a user calls the regular base test functionality, or have you your tests run during CI runs, you can simply add this package TestItemRunner.jl as a test dependency to your package, and then add this content as your `test/runtests.jl` file:
 
 ```julia
 using TestItemRunner
@@ -123,3 +123,11 @@ The value that is passed to your custom filter function has three fields that yo
 - `name`: The full name of the `@testitem`, as a `String`.
 - `filename`: The full absolute filename of the file in which the `@testitem` is defined.
 - `tags`: A `Vector{Symbol}` with all the tags that you defined for this particular `@testitem`.
+
+If you want to print a summary of test results which shows all the `@testitems`, then you can pass `verbose=true`:
+
+```julia
+using TestItemRunner
+
+@run_package_tests verbose=true
+```

--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -130,11 +130,11 @@ function run_tests(path; filter=nothing, verbose=false)
     end
 
     # Run testitems
-    Test.push_testset(Test.DefaultTestSet("Package"; verbose=verbose))
+    Test.push_testset(testset("Package"; verbose=verbose))
     for (file, testitems) in pairs(testitems)
-        Test.push_testset(Test.DefaultTestSet(relpath(file, path); verbose=verbose))
+        Test.push_testset(testset(relpath(file, path); verbose=verbose))
         for testitem in testitems
-            Test.push_testset(Test.DefaultTestSet(testitem.name; verbose=verbose))
+            Test.push_testset(testset(testitem.name; verbose=verbose))
             run_testitem(testitem.filename, testitem.option_default_imports, package_name, testitem.code, testitem.line, testitem.column)
             Test.finish(Test.pop_testset())
         end
@@ -156,6 +156,14 @@ macro run_package_tests(ex...)
     end
 
     :(run_tests(joinpath($(dirname(string(__source__.file))), ".."); $(kwargs...)))
+end
+
+@static if VERSION < v"1.6"
+    # verbose keyword not support before v1.6
+    # https://github.com/JuliaLang/julia/commit/68c71f577275a16fffb743b2058afdc2d635068f
+    testset(a...; verbose=false, kw...) = Test.DefaultTestSet(a...; kw...)
+else
+    testset(a...; kw...) = Test.DefaultTestSet(a...; kw...)
 end
 
 end

--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -124,8 +124,9 @@ function run_tests(path; filter=nothing, verbose=false)
 
     # Filter @testitems
     if filter !== nothing
-        for file in keys(testitems)     
+        for file in keys(testitems)
             testitems[file] = Base.filter(i -> filter((filename=file, name=i.name, tags=i.option_tags)), testitems[file])
+            isempty(testitems[file]) && pop!(testitems, file)
         end
     end
 

--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -77,7 +77,7 @@ function run_testitem(filepath, use_default_usings, package_name, original_code,
     end
 end
 
-function run_tests(path; filter=nothing)
+function run_tests(path; filter=nothing, verbose=false)
     # Find package name
     package_name = ""
     package_filename = isfile(joinpath(path, "Project.toml")) ? joinpath(path, "Project.toml") : isfile(joinpath(path, "JuliaProject.toml")) ? joinpath(path, "JuliaProject.toml") : nothing
@@ -130,11 +130,11 @@ function run_tests(path; filter=nothing)
     end
 
     # Run testitems
-    Test.push_testset(Test.DefaultTestSet("Package"))
+    Test.push_testset(Test.DefaultTestSet("Package"; verbose=verbose))
     for (file, testitems) in pairs(testitems)
-        Test.push_testset(Test.DefaultTestSet(relpath(file, path)))
+        Test.push_testset(Test.DefaultTestSet(relpath(file, path); verbose=verbose))
         for testitem in testitems
-            Test.push_testset(Test.DefaultTestSet(testitem.name))
+            Test.push_testset(Test.DefaultTestSet(testitem.name; verbose=verbose))
             run_testitem(testitem.filename, testitem.option_default_imports, package_name, testitem.code, testitem.line, testitem.column)
             Test.finish(Test.pop_testset())
         end
@@ -146,9 +146,9 @@ end
 
 macro run_package_tests(ex...)
     kwargs = []
-    
+
     for i in ex
-        if i isa Expr && i.head==:(=) && length(i.args)==2 && i.args[1]==:filter
+        if i isa Expr && i.head==:(=) && length(i.args)==2 && i.args[1] in (:filter, :verbose)
             push!(kwargs, esc(i))
         else
             error("Invalid argument")

--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -160,7 +160,7 @@ macro run_package_tests(ex...)
 end
 
 @static if VERSION < v"1.6"
-    # verbose keyword not support before v1.6
+    # verbose keyword not supported before v1.6
     # https://github.com/JuliaLang/julia/commit/68c71f577275a16fffb743b2058afdc2d635068f
     testset(a...; verbose=false, kw...) = Test.DefaultTestSet(a...; kw...)
 else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,3 @@
 using TestItemRunner
 
-@run_package_tests filter=i->endswith(i.filename, "TestItemRunner.jl")
+@run_package_tests filter=i->endswith(i.filename, "TestItemRunner.jl") verbose=true


### PR DESCRIPTION
- To get a summary of all testitems, even when all tests pass.

For example, with `@run_package_tests verbose=true`
```julia
Test Summary:                           | Pass  Total   Time
Package                                 | 5170   5170  15.1s
  test/runtests.jl                      | 5170   5170  15.1s
    InlineString basics                 |  261    261   3.8s
    InlineString operations             | 4114   4114   6.0s
    `string` / `*`                      |   14     14   0.0s
    InlineString parsing                |   79     79   0.6s
    InlineString Serialization symmetry |   20     20   0.8s
    alias tests                         |    8      8   0.0s
    sorting tests                       |   97     97   2.7s
    inlinestrings                       |   19     19   0.9s
    reverse                             |  544    544   0.1s
    macros                              |   10     10   0.0s
    print/show/repr                     |    4      4   0.1s
     Testing InlineStrings tests passed
```
whereas with plain `@run_package_tests` (i.e. with default `verbose=false`)
```julia
Test Summary: | Pass  Total   Time
Package       | 5170   5170  15.2s
     Testing InlineStrings tests passed
```

Related to #36. I thought this might be a nice way to be able to see which TestItems are getting picked up e.g. when running from the REPL.