### PR TITLE
Doc for `testsetup` and cross-module testing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,18 @@ end
     @test TestSetup.getfloat() isa Float64
 end
 
+@testsetup module CrossTestSetup
+    using Test
+    using ..TestSetup: x, getfloat
+    function cross_test()
+        @test x == 10
+        @test getfloat() isa Float64
+    end
+end
+
+@testitem "CrossTestSetup" setup=[TestSetup, CrossTestSetup] begin
+    using .CrossTestSetup: cross_test
+    cross_test()
+end
+
 @run_package_tests filter=i->endswith(i.filename, "TestItemRunner.jl") || endswith(i.filename, "runtests.jl") verbose=true


### PR DESCRIPTION
I have updated the doc regarding the `@testsetup` functionality.

Moreover, I have noticed that cross-module usage is possible, and can come really handy for some complicated set of tests. I have added documentation and tests regarding this as well.
Was it done on purpose, and can I expect it to keep working in the future?

(Also, thanks for this piece of software; I find it extremely useful.)