### PR TITLE
Use temporary `cd`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,9 @@ end
     @test TestSetup.getfloat() isa Float64
 end
 
+dir = pwd()
+
 @run_package_tests filter=i->endswith(i.filename, "TestItemRunner.jl") || endswith(i.filename, "runtests.jl") verbose=true
+
+# Check that @run_package_tests didn't change the working directory
+TestItemRunner.Test.@test pwd() == dir


### PR DESCRIPTION
Calling `@run_package_tests` currently changes the directory to the `test` folder.
For example, including `runtests.jl` twice does not work

```julia-repl
julia> include("test/runtests.jl") # contains `@run_test_items`
# tests run
julia> include("test/runtests.jl")
ERROR: SystemError: opening file "/path/to/MyPackage.jl/test/test/runtests.jl": No such file or directory
Stacktrace:
 [1] include(fname::String)
   @ Main ./sysimg.jl:38
 [2] top-level scope
   @ REPL[16]:1
```

The `cd` function has a functional form, returning to the original directory after finishing which could solve this problem.