### PR TITLE
reexport @testmodule and @testsnippet from TestItems

### DIFF
--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -24,11 +24,11 @@ module TestItemDetection
 end
 
 import Test, TestItems, TOML
-using TestItems: @testitem
+using TestItems: @testitem, @testmodule, @testsnippet
 
 include("vendored_code.jl")
 
-export @run_package_tests, @testitem
+export @run_package_tests, @testitem, @testmodule, @testsnippet
 
 function compute_line_column(content, target_pos)
     line = 1


### PR DESCRIPTION
Reexport `@testmodule` and `@testsnippet` from `TestItems`, to fix: https://github.com/julia-vscode/TestItemRunner.jl/issues/102