### PR TITLE
Use invokelatest to generate test report compatible with custom TestSets

### DIFF
--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -224,7 +224,8 @@ function run_tests(path; filter=nothing, verbose=false)
         Test.finish(Test.pop_testset())
     end
     ts = Test.pop_testset()
-    Test.finish(ts)
+    # Outer testset generates report that needs to integrate results from nested (custom) testsets
+    Base.invokelatest(Test.finish, ts)
 end
 
 """


### PR DESCRIPTION
Fixes #99 

Nested AbstractTestSets integrate with one another by implementing `Test.get_test_counts`. Because this method is defined within the @testitem scope, it isn't known to the outer testset here (world age issue), so it falls back to the default zero TestCount in Test.jl, ignoring any custom TestSet results as seen in #99.